### PR TITLE
New rules

### DIFF
--- a/base/index.js
+++ b/base/index.js
@@ -23,6 +23,7 @@ module.exports = {
     "semi": ["error", "always"],
     "arrow-parens": ["error", "always"],
     "strict": ["error", "never"],
-    "require-yield": "off"
+    "require-yield": "off",
+    "prefer-const": "error"
   }
 };

--- a/base/index.js
+++ b/base/index.js
@@ -21,6 +21,7 @@ module.exports = {
     "no-param-reassign": ["error", { "props": false }],
     "quotes": ["error", "single"],
     "semi": ["error", "always"],
+    "arrow-parens": ["error", "always"],
     "strict": ["error", "never"],
     "require-yield": "off"
   }


### PR DESCRIPTION
- Prefer constant: if a let variable is not reassigned
- arrow parens: enforces the use of parens

Both are covered by eslint --fix, in case you need a quick trick to solved them