### PR TITLE
added globals values for flow

### DIFF
--- a/base/index.js
+++ b/base/index.js
@@ -4,6 +4,21 @@ module.exports = {
     "es6": true,
     "node": true
   },
+  "globals": {
+    "SyntheticEvent": true,
+    "SyntheticAnimationEvent": true,
+    "SyntheticClipboardEvent": true,
+    "SyntheticCompositionEvent": true,
+    "SyntheticInputEvent": true,
+    "SyntheticUIEvent": true,
+    "SyntheticFocusEvent": true,
+    "SyntheticKeyboardEvent": true,
+    "SyntheticMouseEvent": true,
+    "SyntheticDragEvent": true,
+    "SyntheticWheelEvent": true,
+    "SyntheticTouchEvent": true,
+    "SyntheticTransitionEvent": true
+  },
   "parserOptions": {
     "ecmaFeatures": {
       "experimentalObjectRestSpread": true


### PR DESCRIPTION
Last version of flow recommends using flowtypes from react without importing the types explicitly.

This solves that.