### PR TITLE
Remove not needed env variable

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -3,7 +3,6 @@ module.exports = {
     'eslint-config-wizeline',
   ],
   "env": {
-    "server": true,
     "node": true,
   },
 };


### PR DESCRIPTION
# What does this PR do?
- There's an env variable which is wrongly configure and doesn't exist.

### More info
You can find which env variables are supported [here](https://eslint.org/docs/user-guide/configuring#specifying-environments)