### PR TITLE
Bump version to 3.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wizeline/eslint-config-wizeline",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "",
   "main": "index.js",
   "peerDependencies": {


### PR DESCRIPTION
# Highlights
- Correctly configure plugins and extends rules
- Browser env variable now only set on browser configuration